### PR TITLE
Add missing vod domain

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,7 @@ export const VOD_DOMAINS = [
   'https://ddacn6pr5v0tl.cloudfront.net',
   'https://d3aqoihi2n8ty8.cloudfront.net',
   'https://d3fi1amfgojobc.cloudfront.net',
+  'https://d2vi6trrdongqn.cloudfront.net',
 ];
 
 export const DOWNLOADERS = ['aria2c', 'curl', 'fetch'] as const;


### PR DESCRIPTION
One of my streams was not downloading live. Because the channel is set to not auto publish, it tried to use vod domains to resolve the url, but it was failing. After the stream ended I checked the formats and the domain for this vod is missing in the list.